### PR TITLE
fix: Allow space bar to work normally when recording is locked

### DIFF
--- a/dial8 MacOS/Services/GlobalHotkeyManager.swift
+++ b/dial8 MacOS/Services/GlobalHotkeyManager.swift
@@ -399,8 +399,12 @@ class GlobalHotkeyManager: ObservableObject {
                 print("🔒 Push-to-talk: Recording locked - press Option to stop")
                 // Post notification to update UI if needed
                 NotificationCenter.default.post(name: Notification.Name("RecordingLockedStateChanged"), object: nil, userInfo: ["isLocked": true])
+                return nil // Consume the space bar event only when locking
+            } else if isRecordingLocked {
+                // Recording is already locked - let space bar events pass through to other apps
+                return Unmanaged.passRetained(event)
             }
-            return nil // Consume the space bar event (only when Command is not pressed)
+            return nil // Consume the space bar event for keyUp when not locked
         }
         
         // Regular hotkey handling for key press events


### PR DESCRIPTION
When using push-to-talk mode with space bar lock functionality, space bar events were being consumed even after locking, preventing users from typing spaces in other applications. Now space bar events pass through to other apps when recording is already locked.

Fixes #1 